### PR TITLE
Tweaking wording of labels in body text

### DIFF
--- a/coin-web/coin.html
+++ b/coin-web/coin.html
@@ -15,7 +15,7 @@
   <div class="results">
     <p>Heads: <span id="headsCount">0</span></p>
     <p>Tails: <span id="tailsCount">0</span></p>
-    <p>Percentage Heads: <span id="percentageHeads">0</span>%</p>
+    <p>Percentage of heads: <span id="percentageHeads">0</span>%</p>
     <p>Probability of this outcome: <span id="probability">0</span>%</p>
   </div>
   <details>


### PR DESCRIPTION
Added "of" in "Percentage of heads" and also made it sentence case to be consistent with "Number of flips" and "Probability of this outcome"