### PR TITLE
Add error handling for errors from the API

### DIFF
--- a/currency-web/currency.js
+++ b/currency-web/currency.js
@@ -10,6 +10,7 @@ async function getCurrencies() {
 async function convertCurrency(fromCurrency, toCurrency, amount) {
     const response = await fetch(`${BASE_URL}/latest.json?app_id=${APP_ID}&base=${fromCurrency}`);
     const data = await response.json();
+    if(data.error) throw new Error(data.description);
     const converted = data.rates[toCurrency] * amount;
     const ts = new Date(data.timestamp * 1000).toLocaleString();
     return { converted, ts };


### PR DESCRIPTION
The existing code doesn't do this, so it just assumes data.rates exists and tries to access it in convertCurrency(). This means that by the time there is any error handling, inside the button event listener, we just get an unhelpful JS-internal error message (like "Cannot read properties of undefined (reading 'AED')”) rather than the HTTP error that was actually returned by the API (like "This App ID has been deactivated. Please use another or contact support@openexchangerates.org for assistance.“)