### PR TITLE
Removed expired app ID

### DIFF
--- a/currency-web/currency.js
+++ b/currency-web/currency.js
@@ -1,5 +1,5 @@
 BASE_URL = 'https://openexchangerates.org/api';
-APP_ID = 'cfe66050a8494102bf905fbceeffa695';
+APP_ID = 'YOUR_APP_ID'; //replace with your own app ID
 
 async function getCurrencies() {
   const response = await fetch(`${BASE_URL}/currencies.json`);


### PR DESCRIPTION
Changed it to the placeholder "YOUR_APP_ID" like in the solution file, plus a comment telling the reader to change it. (Obviously the currency conversion API request wouldn't actually work with  "YOUR_APP_ID", but it won't work with the existing expired key either, so "YOUR_APP_ID" is no worse.)