### PR TITLE
Swap order of symbol and name

### DIFF
--- a/currency-web/currency.js
+++ b/currency-web/currency.js
@@ -24,7 +24,7 @@ async function populateCurrencies() {
         for (const [symbol, name] of Object.entries(currencies)) {
             const option = document.createElement('option');
             option.value = symbol;
-            option.textContent = `${name} (${symbol})`;
+            option.textContent = `${symbol} (${name})`;
             select.appendChild(option);
         }
     }


### PR DESCRIPTION
Swapped order of currency symbol (e.g. GBP) and full name (e.g. British Pound Sterling) as the list is ordered alphabetically by symbol so it's much easier to navigate when that's displayed first