### PR TITLE
Fixing "Eye Dropper" text and Chrome comment

### DIFF
--- a/eyedropper/eyedropper.html
+++ b/eyedropper/eyedropper.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Eye Dropper Color Picker</title>
+  <title>Eyedropper Color Picker</title>
   <style>
     body {
       text-align: center;
@@ -20,7 +20,7 @@
   </style>
 </head>
 <body>
-  <h1>Eye Dropper Color Picker</h1>
+  <h1>Eyedropper Color Picker</h1>
 
   <div id="eye-dropper">
     <label for="eye-dropper-button">Click the button and then pick a color from anywhere on the screen:</label>
@@ -31,7 +31,7 @@
 
   <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
   <script>
-    // Check if EyeDropper API is supported (for Chrome)
+    // Check if EyeDropper API is supported (for browsers like Chrome and Edge)
     if (typeof EyeDropper !== "function") {
         // Fallback for other browsers (including Firefox)
         $("#eye-dropper").text("Eye Dropper API not supported in this browser.");


### PR DESCRIPTION
In response to your previous comment, instead standardising on "eyedropper" (all one word, and "Eyedropper" when capitalised) for the general concept, and "EyeDropper" for the API.

Same fix to the comment about Chrome, to avoid implying it's the only browser that supports it.