### PR TITLE
Change error message to output argv[0] 

### DIFF
--- a/random-cli/rng.py
+++ b/random-cli/rng.py
@@ -5,7 +5,7 @@ DEFAULT_MIN = 1
 DEFAULT_MAX = 100
 
 if len(sys.argv) > 3:
-  print("Usage: python ./rng [min] [max]")
+  print(f"Usage: python {sys.argv[0]} [min] [max]")
   sys.exit(1)
 
 try:  


### PR DESCRIPTION
Change error message to output argv[0] rather than (incorrect) hardcoded filename

In the previous steps of the solution file, this error message used {sys.argv[0]} for the filename, but in the final step, it was hardcoded as "./rng" (which is incorrect anyway, because it should be "./rng.py"), so I changed it back to {sys.argv[0]} to be consistent and more flexible/correct in case the user calls their file something different.